### PR TITLE
Enhanced WatchOSChecker Function with WatchSession General Check

### DIFF
--- a/src/watchos-connector.ios.ts
+++ b/src/watchos-connector.ios.ts
@@ -17,6 +17,7 @@ export class WatchOSConnector implements WCSessionDelegate {
   watchOSChecker() {
     if (
       isIOS &&
+      this.watchSession &&
       this.watchSession.paired &&
       this.watchSession.watchAppInstalled
     ) {


### PR DESCRIPTION
When using the watchOSChecker function and no Apple Watch is paired, the function throws an exception, because this.watchSession is undefined. This pull request adds another check that the watchSession object is existing and only then it can return true.